### PR TITLE
Test: Don't write to unused local variable on destruction

### DIFF
--- a/test/src/ServerTests.cpp
+++ b/test/src/ServerTests.cpp
@@ -1887,8 +1887,6 @@ TEST_F(ServerTests, UpgradedConnectionsShouldNotBeTimedOutByServer) {
 
     // Connect to server.
     auto connection = std::make_shared< MockConnection >();
-    bool connectionDestroyed = false;
-    connection->onDestruction = [&connectionDestroyed]{ connectionDestroyed = true; };
     transport->connectionDelegate(connection);
 
     // Send a request that should trigger an upgrade.
@@ -1963,8 +1961,6 @@ TEST_F(ServerTests, UpgradedConnectionShouldNoLongerParseRequests) {
 
     // Connect to server.
     auto connection = std::make_shared< MockConnection >();
-    bool connectionDestroyed = false;
-    connection->onDestruction = [&connectionDestroyed]{ connectionDestroyed = true; };
     transport->connectionDelegate(connection);
 
     // Send a request that should trigger an upgrade, but make the data after


### PR DESCRIPTION
The bools connectionDestroyed aren't used and thus can be removed. Also,
the connection->onDestruction lambda would get executed when connection
gets out of the scope, which is at the end of the function. This causes
the AddressSanitizer (or any of the other sanitizers, I forgot) to
complain about invalid memory access, because it would try to access the
connectionDestroyed variable.

For reference the output:

	==20640==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7ffeb7b4ee10 at pc 0x0000007768de bp 0x7ffeb7b4e6d0 sp 0x7ffeb7b4e6c8
	WRITE of size 1 at 0x7ffeb7b4ee10 thread T0
	    #0 0x7768dd in ServerTests_UpgradedConnectionsShouldNotBeTimedOutByServer_Test::TestBody()::$_12::operator()() const Http/test/src/ServerTests.cpp:1891:77
	    #1 0x77639c in std::_Function_handler<void (), ServerTests_UpgradedConnectionsShouldNotBeTimedOutByServer_Test::TestBody()::$_12>::_M_invoke(std::_Any_data const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/std_function.h:297:2
	    #2 0x6539d8 in std::function<void ()>::operator()() const /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/std_function.h:687:14
	    #3 0x761b00 in (anonymous namespace)::MockConnection::~MockConnection() Http/test/src/ServerTests.cpp:86:17
	    #4 0x761733 in void __gnu_cxx::new_allocator<(anonymous namespace)::MockConnection>::destroy<(anonymous namespace)::MockConnection>((anonymous namespace)::MockConnection*) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/ext/new_allocator.h:140:28
	    #5 0x76151c in void std::allocator_traits<std::allocator<(anonymous namespace)::MockConnection> >::destroy<(anonymous namespace)::MockConnection>(std::allocator<(anonymous namespace)::MockConnection>&, (anonymous namespace)::MockConnection*) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/alloc_traits.h:487:8
	    #6 0x75f48c in std::_Sp_counted_ptr_inplace<(anonymous namespace)::MockConnection, std::allocator<(anonymous namespace)::MockConnection>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr_base.h:554:2
	    #7 0x634fea in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr_base.h:155:6
	    #8 0x634e21 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr_base.h:728:11
	    #9 0x689aa8 in std::__shared_ptr<Http::Connection, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr_base.h:1167:31
	    #10 0x6315e4 in std::shared_ptr<Http::Connection>::~shared_ptr() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr.h:103:11
	    #11 0x706645 in ServerTests_UpgradedConnectionsShouldNotBeTimedOutByServer_Test::TestBody() Http/test/src/ServerTests.cpp:1917:1
	    #12 0xa8018b in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) googletest/googletest/src/gtest.cc:2611:10
	    #13 0xa0b49a in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) googletest/googletest/src/gtest.cc:2647:14
	    #14 0x986ac9 in testing::Test::Run() googletest/googletest/src/gtest.cc:2686:5
	    #15 0x98a1d4 in testing::TestInfo::Run() googletest/googletest/src/gtest.cc:2863:11
	    #16 0x98d812 in testing::TestSuite::Run() googletest/googletest/src/gtest.cc:3017:28
	    #17 0x9c25cb in testing::internal::UnitTestImpl::RunAllTests() googletest/googletest/src/gtest.cc:5709:44
	    #18 0xa93c4b in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) googletest/googletest/src/gtest.cc:2611:10
	    #19 0xa1815a in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) googletest/googletest/src/gtest.cc:2647:14
	    #20 0x9c03d0 in testing::UnitTest::Run() googletest/googletest/src/gtest.cc:5292:10
	    #21 0x7b768c in RUN_ALL_TESTS() googletest/googletest/include/gtest/gtest.h:2485:46
	    #22 0x7b74f9 in main googletest/googletest/src/gtest_main.cc:52:10
	    #23 0x7fc0ec55ab96 in __libc_start_main /build/glibc-OTsEL5/glibc-2.27/csu/../csu/libc-start.c:310
	    #24 0x451a79 in _start (buildclang/Http/test/HttpTests+0x451a79)

	Address 0x7ffeb7b4ee10 is located in stack of thread T0 at offset 944 in frame
	    #0 0x703c7f in ServerTests_UpgradedConnectionsShouldNotBeTimedOutByServer_Test::TestBody() Http/test/src/ServerTests.cpp:1849

	  This frame has 44 object(s):
	    [32, 48) 'transport' (line 1851)
	    [64, 80) 'timeKeeper' (line 1852)
	    [96, 128) 'deps' (line 1853)
	    [160, 192) 'ref.tmp' (line 1856)
	    [224, 225) 'ref.tmp14' (line 1856)
	    [240, 272) 'ref.tmp17' (line 1856)
	    [304, 305) 'ref.tmp18' (line 1856)
	    [320, 352) 'ref.tmp40' (line 1857)
	    [384, 385) 'ref.tmp41' (line 1857)
	    [400, 432) 'ref.tmp44' (line 1857)
	    [464, 465) 'ref.tmp45' (line 1857)
	    [480, 481) 'requestReceived' (line 1862)
	    [496, 512) 'upgradedConnection' (line 1863)
	    [528, 544) 'resourceDelegate' (line 1864)
	    [560, 592) 'unregistrationDelegate' (line 1886)
	    [624, 648) 'ref.tmp83' (line 1886)
	    [688, 704) 'agg.tmp'
	    [720, 752) 'ref.tmp84' (line 1886)
	    [784, 785) 'ref.tmp85' (line 1886)
	    [800, 801) 'ref.tmp88' (line 1886)
	    [816, 848) 'agg.tmp91'
	    [880, 896) 'agg.tmp92'
	    [912, 928) 'connection' (line 1889)
	    [944, 945) 'connectionDestroyed' (line 1890) <== Memory access at offset 944 is inside this variable
	    [960, 968) 'ref.tmp121' (line 1891)
	    [992, 1024) 'agg.tmp.ensured'
	    [1056, 1072) 'agg.tmp144'
	    [1088, 1120) 'request' (line 1895)
	    [1152, 1153) 'ref.tmp148' (line 1895)
	    [1168, 1192) 'ref.tmp162' (line 1901)
	    [1232, 1240) 'agg.tmp163'
	    [1264, 1272) 'agg.tmp165'
	    [1296, 1297) 'ref.tmp168' (line 1901)
	    [1312, 1336) 'client' (line 1907)
	    [1376, 1392) 'response' (line 1908)
	    [1408, 1440) 'ref.tmp181' (line 1908)
	    [1472, 1480) 'agg.tmp182'
	    [1504, 1512) 'agg.tmp194'
	    [1536, 1537) 'ref.tmp207' (line 1908)
	    [1552, 1568) 'gtest_ar_' (line 1916)
	    [1584, 1585) 'ref.tmp237' (line 1916)
	    [1600, 1608) 'ref.tmp253' (line 1916)
	    [1632, 1640) 'ref.tmp256' (line 1916)
	    [1664, 1696) 'ref.tmp257' (line 1916)
	HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
	      (longjmp and C++ exceptions *are* supported)
	SUMMARY: AddressSanitizer: stack-use-after-scope Http/test/src/ServerTests.cpp:1891:77 in ServerTests_UpgradedConnectionsShouldNotBeTimedOutByServer_Test::TestBody()::$_12::operator()() const
	Shadow bytes around the buggy address:
	  0x100056f61d70: f2 f2 f8 f2 f8 f8 f8 f8 f2 f2 f2 f2 f8 f2 f8 f8
	  0x100056f61d80: f8 f8 f2 f2 f2 f2 f8 f2 01 f2 00 00 f2 f2 f8 f8
	  0x100056f61d90: f2 f2 f8 f8 f8 f8 f2 f2 f2 f2 f8 f8 f8 f2 f2 f2
	  0x100056f61da0: f2 f2 00 00 f2 f2 f8 f8 f8 f8 f2 f2 f2 f2 f8 f2
	  0x100056f61db0: f8 f2 00 00 00 00 f2 f2 f2 f2 00 00 f2 f2 f8 f8
	=>0x100056f61dc0: f2 f2[f8]f2 f8 f2 f2 f2 00 00 00 00 f2 f2 f2 f2
	  0x100056f61dd0: 00 00 f2 f2 f8 f8 f8 f8 f2 f2 f2 f2 f8 f2 f8 f8
	  0x100056f61de0: f8 f2 f2 f2 f2 f2 00 f2 f2 f2 00 f2 f2 f2 f8 f2
	  0x100056f61df0: f8 f8 f8 f2 f2 f2 f2 f2 f8 f8 f2 f2 f8 f8 f8 f8
	  0x100056f61e00: f2 f2 f2 f2 00 f2 f2 f2 00 f2 f2 f2 f8 f2 f8 f8
	  0x100056f61e10: f2 f2 f8 f2 f8 f2 f2 f2 f8 f2 f2 f2 f8 f8 f8 f8
	Shadow byte legend (one shadow byte represents 8 application bytes):
	  Addressable:           00
	  Partially addressable: 01 02 03 04 05 06 07
	  Heap left redzone:       fa
	  Freed heap region:       fd
	  Stack left redzone:      f1
	  Stack mid redzone:       f2
	  Stack right redzone:     f3
	  Stack after return:      f5
	  Stack use after scope:   f8
	  Global redzone:          f9
	  Global init order:       f6
	  Poisoned by user:        f7
	  Container overflow:      fc
	  Array cookie:            ac
	  Intra object redzone:    bb
	  ASan internal:           fe
	  Left alloca redzone:     ca
	  Right alloca redzone:    cb
	  Shadow gap:              cc
	==20640==ABORTING
